### PR TITLE
Add read/write hooks to ZERO (ensure immutability)

### DIFF
--- a/symex/src/arch/risc_v/mod.rs
+++ b/symex/src/arch/risc_v/mod.rs
@@ -115,9 +115,6 @@ impl<Override: ArchitectureOverride> Architecture<Override> for RISCV {
 
         // Writing to zero register should not change the state.
         let write_zero = |state: &mut GAState<C>, _value: C::SmtExpression| {
-            let size = state.current_instruction.as_ref().unwrap().instruction_size;
-            let zero = state.memory.from_u64(0u64, size);
-            state.memory.set_register("ZERO", zero);
             trace!("Writing to zero register, no effect");
             Ok(())
         };

--- a/symex/src/arch/risc_v/mod.rs
+++ b/symex/src/arch/risc_v/mod.rs
@@ -113,20 +113,14 @@ impl<Override: ArchitectureOverride> Architecture<Override> for RISCV {
             trace!("Could not add hardfault hook");
         }
 
-        // Ensure that the zero register is always read as zero.
-        let read_zero = |state: &mut GAState<C>| {
-            let size = state.current_instruction.as_ref().unwrap().instruction_size;
-            let zero = state.memory.from_u64(0, size);
-            Ok(zero)
-        };
         // Writing to zero register should not change the state.
         let write_zero = |state: &mut GAState<C>, _value: C::SmtExpression| {
             let size = state.current_instruction.as_ref().unwrap().instruction_size;
             let zero = state.memory.from_u64(0u64, size);
             state.memory.set_register("ZERO", zero);
+            trace!("Writing to zero register, no effect");
             Ok(())
         };
-        cfg.add_register_read_hook("ZERO".to_owned(), read_zero);
         cfg.add_register_write_hook("ZERO".to_owned(), write_zero);
 
     }
@@ -147,6 +141,8 @@ impl<Override: ArchitectureOverride> Architecture<Override> for RISCV {
     where
         C: Composition<ArchitectureOverride = Override>,
     {
+        trace!("Setting ZERO register to zero");
+        state.memory.set_register("ZERO", state.memory.from_u64(0, 32));
     }
 
     fn get_register_name(reg: InterfaceRegister) -> String {

--- a/symex/src/arch/risc_v/mod.rs
+++ b/symex/src/arch/risc_v/mod.rs
@@ -112,6 +112,23 @@ impl<Override: ArchitectureOverride> Architecture<Override> for RISCV {
         if let Err(_) = cfg.add_pc_hook_regex(map, r"^HardFault.*$", PCHook::EndFailure("Hardfault")) {
             trace!("Could not add hardfault hook");
         }
+
+        // Ensure that the zero register is always read as zero.
+        let read_zero = |state: &mut GAState<C>| {
+            let size = state.current_instruction.as_ref().unwrap().instruction_size;
+            let zero = state.memory.from_u64(0, size);
+            Ok(zero)
+        };
+        // Writing to zero register should not change the state.
+        let write_zero = |state: &mut GAState<C>, _value: C::SmtExpression| {
+            let size = state.current_instruction.as_ref().unwrap().instruction_size;
+            let zero = state.memory.from_u64(0u64, size);
+            state.memory.set_register("ZERO", zero);
+            Ok(())
+        };
+        cfg.add_register_read_hook("ZERO".to_owned(), read_zero);
+        cfg.add_register_write_hook("ZERO".to_owned(), write_zero);
+
     }
 
     fn pre_instruction_loading_hook<C>(state: &mut GAState<C>)


### PR DESCRIPTION
Compiler does write to zero in some cases, e.g. for non-linking jumps:
```
jal    zero,20400314 <get_sign+0x4c>
```

Add read/write hooks to ZERO to ensure immutability